### PR TITLE
Hotfix/bean coffee

### DIFF
--- a/api/src/main/kotlin/com/wnsgml972/strada/api/v1/item/coffee/domain/BeanCoffee.kt
+++ b/api/src/main/kotlin/com/wnsgml972/strada/api/v1/item/coffee/domain/BeanCoffee.kt
@@ -1,7 +1,7 @@
 package com.wnsgml972.strada.api.v1.item.coffee.domain
 
 import com.fasterxml.jackson.annotation.JsonManagedReference
-import com.wnsgml972.strada.api.base.LongJpaEntity
+import com.wnsgml972.strada.api.base.AbstractValueObject
 import javax.persistence.ManyToOne
 import javax.persistence.Entity
 import javax.persistence.Id
@@ -26,7 +26,7 @@ class BeanCoffee(
     @ManyToOne(fetch = FetchType.LAZY, cascade = [CascadeType.PERSIST, CascadeType.MERGE])
     var bean: Bean?,
 
-) : LongJpaEntity() {
+) : AbstractValueObject() {
 
     override fun equalProperties(other: Any): Boolean {
         return other is BeanCoffee &&

--- a/api/src/test/resources/junit-platform.properties
+++ b/api/src/test/resources/junit-platform.properties
@@ -1,5 +1,1 @@
 junit.jupiter.testinstance.lifecycle.default = per_class
-
-junit.jupiter.execution.parallel.enabled = true
-junit.jupiter.execution.parallel.mode.default = concurrent
-junit.jupiter.execution.parallel.mode.classes.default = concurrent

--- a/api/src/test/resources/junit-platform.properties
+++ b/api/src/test/resources/junit-platform.properties
@@ -1,1 +1,5 @@
 junit.jupiter.testinstance.lifecycle.default = per_class
+
+junit.jupiter.execution.parallel.enabled = true
+junit.jupiter.execution.parallel.mode.default = concurrent
+junit.jupiter.execution.parallel.mode.classes.default = concurrent


### PR DESCRIPTION
BeanCoffee 클래스의 Primary key가 중복되는 문제 조치