### PR TITLE
orderingdetail entity to id

### DIFF
--- a/api/src/main/kotlin/com/wnsgml972/strada/api/v1/ordering/domain/OrderingDetail.kt
+++ b/api/src/main/kotlin/com/wnsgml972/strada/api/v1/ordering/domain/OrderingDetail.kt
@@ -10,7 +10,6 @@ import com.wnsgml972.strada.api.v1.product.coffee.domain.Coffee
 import com.wnsgml972.strada.api.v1.product.noncoffee.domain.NonCoffee
 import javax.persistence.CascadeType
 import javax.persistence.Entity
-import javax.persistence.JoinColumn
 import javax.persistence.OneToOne
 
 /**
@@ -25,19 +24,15 @@ import javax.persistence.OneToOne
 @SuppressWarnings("LongParameterList")
 class OrderingDetail private constructor(
     @OneToOne
-    @JoinColumn(name = "coffee_id")
     val coffee: Coffee?,
 
     @OneToOne
-    @JoinColumn(name = "non_coffee_id")
     val nonCoffee: NonCoffee?,
 
     @OneToOne
-    @JoinColumn(name = "bread_id")
     val bread: Bread?,
 
     @OneToOne
-    @JoinColumn(name = "bean_id")
     val bean: Bean?,
 
     @OneToOne(cascade = [CascadeType.ALL])

--- a/api/src/main/kotlin/com/wnsgml972/strada/api/v1/ordering/domain/OrderingDetail.kt
+++ b/api/src/main/kotlin/com/wnsgml972/strada/api/v1/ordering/domain/OrderingDetail.kt
@@ -10,6 +10,7 @@ import com.wnsgml972.strada.api.v1.product.coffee.domain.Coffee
 import com.wnsgml972.strada.api.v1.product.noncoffee.domain.NonCoffee
 import javax.persistence.CascadeType
 import javax.persistence.Entity
+import javax.persistence.JoinColumn
 import javax.persistence.OneToOne
 
 /**
@@ -24,15 +25,19 @@ import javax.persistence.OneToOne
 @SuppressWarnings("LongParameterList")
 class OrderingDetail private constructor(
     @OneToOne
+    @JoinColumn(name = "coffee_id")
     val coffee: Coffee?,
 
     @OneToOne
+    @JoinColumn(name = "non_coffee_id")
     val nonCoffee: NonCoffee?,
 
     @OneToOne
+    @JoinColumn(name = "bread_id")
     val bread: Bread?,
 
     @OneToOne
+    @JoinColumn(name = "bean_id")
     val bean: Bean?,
 
     @OneToOne(cascade = [CascadeType.ALL])

--- a/api/src/main/kotlin/com/wnsgml972/strada/api/v1/ordering/domain/OrderingDetail.kt
+++ b/api/src/main/kotlin/com/wnsgml972/strada/api/v1/ordering/domain/OrderingDetail.kt
@@ -23,16 +23,16 @@ import javax.persistence.OneToOne
 @Entity
 @SuppressWarnings("LongParameterList")
 class OrderingDetail private constructor(
-    @OneToOne
+    @OneToOne(cascade = [CascadeType.MERGE, CascadeType.REFRESH])
     val coffee: Coffee?,
 
-    @OneToOne
+    @OneToOne(cascade = [CascadeType.MERGE, CascadeType.REFRESH])
     val nonCoffee: NonCoffee?,
 
-    @OneToOne
+    @OneToOne(cascade = [CascadeType.MERGE, CascadeType.REFRESH])
     val bread: Bread?,
 
-    @OneToOne
+    @OneToOne(cascade = [CascadeType.MERGE, CascadeType.REFRESH])
     val bean: Bean?,
 
     @OneToOne(cascade = [CascadeType.ALL])

--- a/api/src/main/kotlin/com/wnsgml972/strada/api/v1/ordering/service/OrderingDetailDTO.kt
+++ b/api/src/main/kotlin/com/wnsgml972/strada/api/v1/ordering/service/OrderingDetailDTO.kt
@@ -1,19 +1,15 @@
 package com.wnsgml972.strada.api.v1.ordering.service
 
-import com.wnsgml972.strada.api.v1.product.bean.service.BeanDTO
-import com.wnsgml972.strada.api.v1.product.bread.service.BreadDTO
-import com.wnsgml972.strada.api.v1.product.coffee.service.CoffeeDTO
-import com.wnsgml972.strada.api.v1.product.noncoffee.service.NonCoffeeDTO
 import com.wnsgml972.strada.api.v1.option.bean.service.BeanOptionDTO
 import com.wnsgml972.strada.api.v1.option.bread.service.BreadOptionDTO
 import com.wnsgml972.strada.api.v1.option.drink.service.DrinkOptionDTO
 
 data class OrderingDetailDTO(
     val id: Long,
-    val coffee: CoffeeDTO?,
-    val nonCoffee: NonCoffeeDTO?,
-    val bread: BreadDTO?,
-    val bean: BeanDTO?,
+    val coffeeName: String?,
+    val nonCoffeeId: String?,
+    val breadId: String?,
+    val beanId: String?,
     val drinkOption: DrinkOptionDTO?,
     val breadOption: BreadOptionDTO?,
     val beanOption: BeanOptionDTO?,

--- a/api/src/main/kotlin/com/wnsgml972/strada/api/v1/ordering/service/OrderingDetailMapper.kt
+++ b/api/src/main/kotlin/com/wnsgml972/strada/api/v1/ordering/service/OrderingDetailMapper.kt
@@ -1,40 +1,29 @@
 package com.wnsgml972.strada.api.v1.ordering.service
 
 import com.wnsgml972.strada.api.v1.option.bean.service.toDto
-import com.wnsgml972.strada.api.v1.option.bean.service.toEntity
 import com.wnsgml972.strada.api.v1.option.bread.service.toDto
-import com.wnsgml972.strada.api.v1.option.bread.service.toEntity
 import com.wnsgml972.strada.api.v1.option.drink.service.toDto
-import com.wnsgml972.strada.api.v1.option.drink.service.toEntity
 import com.wnsgml972.strada.api.v1.ordering.domain.OrderingDetail
-import com.wnsgml972.strada.api.v1.product.bean.service.toDto
-import com.wnsgml972.strada.api.v1.product.bean.service.toEntity
-import com.wnsgml972.strada.api.v1.product.bread.service.toDto
-import com.wnsgml972.strada.api.v1.product.bread.service.toEntity
-import com.wnsgml972.strada.api.v1.product.coffee.service.toDto
-import com.wnsgml972.strada.api.v1.product.coffee.service.toEntity
-import com.wnsgml972.strada.api.v1.product.noncoffee.service.toDto
-import com.wnsgml972.strada.api.v1.product.noncoffee.service.toEntity
 import com.wnsgml972.strada.exception.StradaBadRequestException
 
 fun OrderingDetail.toDto() = OrderingDetailDTO(
     this.id ?: throw StradaBadRequestException("$id must not null"),
-    this.coffee?.toDto(),
-    this.nonCoffee?.toDto(),
-    this.bread?.toDto(),
-    this.bean?.toDto(),
+    this.coffee?.name,
+    this.nonCoffee?.id,
+    this.bread?.id,
+    this.bean?.id,
     this.drinkOption?.toDto(),
     this.breadOption?.toDto(),
     this.beanOption?.toDto()
 )
 
-fun OrderingDetailRequest.toEntity(id: Long? = null) = OrderingDetail.of(
-    this.coffeeDTO?.toEntity(),
-    this.nonCoffeeDTO?.toEntity(),
-    this.breadDTO?.toEntity(),
-    this.beanDTO?.toEntity(),
-    this.drinkOptionRequest?.toEntity(),
-    this.breadOptionRequest?.toEntity(),
-    this.beanOptionRequest?.toEntity(),
-    id,
-)
+// fun OrderingDetailRequest.toEntity(id: Long? = null) = OrderingDetail.of(
+//    this.coffeeName
+//    this.nonCoffeeId,
+//    this.breadId,
+//    this.beanId,
+//    this.drinkOptionRequest?.toEntity(),
+//    this.breadOptionRequest?.toEntity(),
+//    this.beanOptionRequest?.toEntity(),
+//    id,
+// )

--- a/api/src/main/kotlin/com/wnsgml972/strada/api/v1/ordering/service/OrderingDetailRequest.kt
+++ b/api/src/main/kotlin/com/wnsgml972/strada/api/v1/ordering/service/OrderingDetailRequest.kt
@@ -1,18 +1,14 @@
 package com.wnsgml972.strada.api.v1.ordering.service
 
-import com.wnsgml972.strada.api.v1.product.bean.service.BeanDTO
-import com.wnsgml972.strada.api.v1.product.bread.service.BreadDTO
-import com.wnsgml972.strada.api.v1.product.coffee.service.CoffeeDTO
-import com.wnsgml972.strada.api.v1.product.noncoffee.service.NonCoffeeDTO
 import com.wnsgml972.strada.api.v1.option.bean.service.BeanOptionRequest
 import com.wnsgml972.strada.api.v1.option.bread.service.BreadOptionRequest
 import com.wnsgml972.strada.api.v1.option.drink.service.DrinkOptionRequest
 
 data class OrderingDetailRequest(
-    val coffeeDTO: CoffeeDTO?,
-    val nonCoffeeDTO: NonCoffeeDTO?,
-    val breadDTO: BreadDTO?,
-    val beanDTO: BeanDTO?,
+    val coffeeName: String?,
+    val nonCoffeeId: String?,
+    val breadId: String?,
+    val beanId: String?,
     val drinkOptionRequest: DrinkOptionRequest?,
     val breadOptionRequest: BreadOptionRequest?,
     val beanOptionRequest: BeanOptionRequest?,

--- a/api/src/main/kotlin/com/wnsgml972/strada/api/v1/ordering/service/OrderingMapper.kt
+++ b/api/src/main/kotlin/com/wnsgml972/strada/api/v1/ordering/service/OrderingMapper.kt
@@ -3,18 +3,9 @@ package com.wnsgml972.strada.api.v1.ordering.service
 import com.wnsgml972.strada.api.v1.ordering.domain.Ordering
 import com.wnsgml972.strada.exception.StradaBadRequestException
 
-import java.time.LocalDateTime
-
 fun Ordering.toDto() = OrderingDTO(
     this.id ?: throw StradaBadRequestException("$id must not null"),
     this.status,
     this.createdAt,
     this.orderingDetails.map { it.toDto() }
-)
-
-fun OrderingRequest.toEntity(id: Long? = null) = Ordering.of(
-    this.status,
-    LocalDateTime.now(),
-    this.orderingDetailRequests.map { it.toEntity() },
-    id,
 )

--- a/api/src/main/kotlin/com/wnsgml972/strada/api/v1/ordering/service/OrderingService.kt
+++ b/api/src/main/kotlin/com/wnsgml972/strada/api/v1/ordering/service/OrderingService.kt
@@ -1,14 +1,33 @@
 package com.wnsgml972.strada.api.v1.ordering.service
 
+import com.wnsgml972.strada.api.v1.item.bread.service.BreadService
+import com.wnsgml972.strada.api.v1.option.bean.service.toEntity
+import com.wnsgml972.strada.api.v1.option.bread.service.toEntity
+import com.wnsgml972.strada.api.v1.option.drink.service.toEntity
+import com.wnsgml972.strada.api.v1.ordering.domain.Ordering
+import com.wnsgml972.strada.api.v1.ordering.domain.OrderingDetail
 import com.wnsgml972.strada.api.v1.ordering.domain.OrderingRepository
+import com.wnsgml972.strada.api.v1.product.bean.service.BeanService
+import com.wnsgml972.strada.api.v1.product.bean.service.toEntity
+import com.wnsgml972.strada.api.v1.product.bread.service.toEntity
+import com.wnsgml972.strada.api.v1.product.coffee.service.CoffeeService
+import com.wnsgml972.strada.api.v1.product.coffee.service.toEntity
+import com.wnsgml972.strada.api.v1.product.noncoffee.service.NonCoffeeService
+import com.wnsgml972.strada.api.v1.product.noncoffee.service.toEntity
 import com.wnsgml972.strada.exception.StradaNotFoundException
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
+import java.time.LocalDateTime
 
 @Service
 class OrderingService(
-    private val orderingRepository: OrderingRepository
+    private val orderingRepository: OrderingRepository,
+
+    private val coffeeService: CoffeeService,
+    private val nonCoffeeService: NonCoffeeService,
+    private val breadService: BreadService,
+    private val beanService: BeanService
 ) {
     @Transactional(readOnly = true)
     fun selectAll(): List<OrderingDTO> {
@@ -26,7 +45,7 @@ class OrderingService(
     @Transactional
     fun insert(orderingRequest: OrderingRequest): OrderingDTO {
         return orderingRepository
-            .save(orderingRequest.toEntity())
+            .save(toEntity(orderingRequest))
             .toDto()
     }
 
@@ -34,7 +53,7 @@ class OrderingService(
     fun update(id: Long, orderingRequest: OrderingRequest): OrderingDTO {
         return orderingRepository.findById(id)
             .orElseThrow { StradaNotFoundException("$id is not found") }
-            .let { orderingRepository.save(orderingRequest.toEntity(id)).toDto() }
+            .let { orderingRepository.save(toEntity(orderingRequest, id)).toDto() }
     }
 
     @Transactional
@@ -42,5 +61,25 @@ class OrderingService(
         orderingRepository.findById(id)
             .orElseThrow { StradaNotFoundException("$id is not found") }
             .run { orderingRepository.delete(this) }
+    }
+
+    private fun toEntity(orderingRequest: OrderingRequest, id: Long? = null): Ordering {
+        return Ordering.of(
+            orderingRequest.status,
+            LocalDateTime.now(),
+            orderingRequest.orderingDetailRequests.map {
+                OrderingDetail.of(
+                    it.coffeeName?.let { name -> coffeeService.select(name).toEntity() },
+                    it.nonCoffeeId?.let { id -> nonCoffeeService.selectById(id).toEntity() },
+                    it.breadId?.let { id -> breadService.selectById(id).toEntity() },
+                    it.beanId?.let { id -> beanService.selectById(id)?.toEntity() },
+                    it.drinkOptionRequest?.toEntity(),
+                    it.breadOptionRequest?.toEntity(),
+                    it.beanOptionRequest?.toEntity(),
+                    null
+                )
+            },
+            id
+        )
     }
 }

--- a/api/src/test/kotlin/com/wnsgml972/strada/api/ordering/OrderingControllerIT.kt
+++ b/api/src/test/kotlin/com/wnsgml972/strada/api/ordering/OrderingControllerIT.kt
@@ -64,7 +64,7 @@ class OrderingControllerIT @Autowired constructor(
         val accessToken = authHelper.getAccessToken()
         val orderingRequest = OrderingRequest(OrderingStatus.REQUEST, listOf<OrderingDetailRequest>(
             OrderingDetailRequest(
-                coffeeDTO,
+                coffeeDTO.name,
                 null,
                 null,
                 null,
@@ -112,7 +112,7 @@ class OrderingControllerIT @Autowired constructor(
             OrderingDetailRequest(
                 null,
                 null,
-                breadDTO,
+                breadDTO.id,
                 null,
                 null,
                 BreadOptionRequest(
@@ -154,7 +154,7 @@ class OrderingControllerIT @Autowired constructor(
                 null,
                 null,
                 null,
-                beanDTO,
+                beanDTO.id,
                 null,
                 null,
                 BeanOptionRequest(

--- a/api/src/test/kotlin/com/wnsgml972/strada/api/ordering/OrderingControllerIT.kt
+++ b/api/src/test/kotlin/com/wnsgml972/strada/api/ordering/OrderingControllerIT.kt
@@ -20,9 +20,9 @@ import com.wnsgml972.strada.api.v1.ordering.service.OrderingRequest
 import com.wnsgml972.strada.api.v1.ordering.service.OrderingStatus
 import com.wnsgml972.strada.api.v1.product.bean.service.BeanDTO
 import com.wnsgml972.strada.api.v1.product.bread.service.BreadDTO
-import com.wnsgml972.strada.api.v1.product.coffee.service.CoffeeDTO
 import com.wnsgml972.strada.api.v1.product.coffee.service.CoffeeInsertRequest
 import mu.KLogging
+import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
@@ -34,37 +34,82 @@ class OrderingControllerIT @Autowired constructor(
     private val client: WebTestClient,
     private val authHelper: AuthHelper,
     private val productHelper: ProductHelper,
+    private val orderingHelper: OrderingHelper,
 ) : IntegrationTest() {
 
-    @Test
-    fun `아이스 아메리카노 5샷 벤티 사이즈 재사용 컵으로 한잔이요`() {
-        val beanDTO = productHelper.insertBean(
+    @BeforeEach
+    fun `메뉴 생성`() {
+        println("Before Each function")
+        val coffeeBeanDTO = productHelper.insertBean(
             BeanDTO(
-            "dummy_bean",
-            "dummy",
-            "bean",
-            "",
-            "",
-            "",
-            "",
-            ""
+                COFFEE_BEAN_ID,
+                "coffee",
+                "bean",
+                "",
+                "",
+                "",
+                "",
+                ""
             )
         )
+
         val coffeeDTO = productHelper.insertCoffee(
-            "americano",
+            COFFEE_NAME,
             CoffeeInsertRequest(
                 "",
                 4400,
                 "",
                 "",
-                listOf<BeanDTO>(beanDTO)
+                listOf<BeanDTO>(coffeeBeanDTO)
             )
         )
 
+        val breadDTO = productHelper.insertBread(
+            BreadDTO(
+                BREAD_ID,
+                "",
+                5600,
+                "",
+                ""
+            )
+        )
+
+        val beanDTO = productHelper.insertBean(
+            BeanDTO(
+                BEAN_ID,
+                "Indo",
+                "nesian",
+                "",
+                "",
+                "",
+                "",
+                ""
+            )
+        )
+    }
+
+    @AfterEach
+    fun `메뉴 삭제`(){
+        orderingHelper.clearOrdering()
+
+        println("After Each function")
+        println("delete bread function")
+        productHelper.deleteBread(BREAD_ID)
+        println("delete bean function")
+        productHelper.deleteBean(BEAN_ID)
+
+        println("delete coffee function")
+        productHelper.deleteCoffee(COFFEE_NAME)
+        println("delete coffee bean function")
+        productHelper.deleteBean(COFFEE_BEAN_ID)
+    }
+
+    @Test
+    fun `아이스 아메리카노 5샷 벤티 사이즈 재사용 컵으로 한잔이요`() {
         val accessToken = authHelper.getAccessToken()
         val orderingRequest = OrderingRequest(OrderingStatus.REQUEST, listOf<OrderingDetailRequest>(
             OrderingDetailRequest(
-                coffeeDTO.name,
+                COFFEE_NAME,
                 null,
                 null,
                 null,
@@ -99,20 +144,12 @@ class OrderingControllerIT @Autowired constructor(
 
     @Test
     fun `크로크무슈 포크 2개넣어서 포장이요`() {
-        val breadDTO = productHelper.insertBread(BreadDTO(
-            "Croque_Monsieur",
-            "",
-            5600,
-            "",
-            ""
-        ))
-
         val accessToken = authHelper.getAccessToken()
         val orderingRequest = OrderingRequest(OrderingStatus.REQUEST, listOf<OrderingDetailRequest>(
             OrderingDetailRequest(
                 null,
                 null,
-                breadDTO.id,
+                BREAD_ID,
                 null,
                 null,
                 BreadOptionRequest(
@@ -135,26 +172,13 @@ class OrderingControllerIT @Autowired constructor(
 
     @Test
     fun `인도네시아 만델링 원두 드립으로 내려먹을 1팩이요`() {
-        val beanDTO = productHelper.insertBean(
-            BeanDTO(
-                "Indonesian_Mandeling",
-                "Indo",
-                "nesian",
-                "",
-                "",
-                "",
-                "",
-                ""
-            )
-        )
-
         val accessToken = authHelper.getAccessToken()
         val orderingRequest = OrderingRequest(OrderingStatus.REQUEST, listOf<OrderingDetailRequest>(
             OrderingDetailRequest(
                 null,
                 null,
                 null,
-                beanDTO.id,
+                BEAN_ID,
                 null,
                 null,
                 BeanOptionRequest(
@@ -173,5 +197,14 @@ class OrderingControllerIT @Autowired constructor(
             .expectBody<OrderingDTO>()
     }
 
-    companion object : KLogging()
+    companion object : KLogging() {
+        private const val COFFEE_BEAN_ID = "chrismas blend"
+        private const val COFFEE_NAME = "americano"
+
+        private const val NONCOFFEE_ID = ""
+
+        private const val BREAD_ID = "Croque_Monsieur"
+
+        private const val BEAN_ID = "Indonesian_Mandeling"
+    }
 }

--- a/api/src/test/kotlin/com/wnsgml972/strada/api/ordering/OrderingHelper.kt
+++ b/api/src/test/kotlin/com/wnsgml972/strada/api/ordering/OrderingHelper.kt
@@ -1,0 +1,27 @@
+package com.wnsgml972.strada.api.ordering
+
+import com.wnsgml972.strada.api.v1.ordering.domain.OrderingDetail
+import com.wnsgml972.strada.api.v1.ordering.service.OrderingDetailRequest
+import com.wnsgml972.strada.api.v1.ordering.service.OrderingRequest
+import com.wnsgml972.strada.api.v1.ordering.service.OrderingService
+import com.wnsgml972.strada.api.v1.ordering.service.OrderingStatus
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.stereotype.Component
+
+@Component
+class OrderingHelper @Autowired constructor(
+    private val orderingService: OrderingService,
+) {
+    fun createOrdering(status: OrderingStatus, orderingDetailRequests: List<OrderingDetailRequest>) =
+        orderingService.insert(OrderingRequest(OrderingStatus.REQUEST, orderingDetailRequests))
+
+    fun deleteOrdering(id: Long) =
+        orderingService.delete(id)
+
+    fun clearOrdering() =
+        orderingService
+            .selectAll()
+            .map {
+                orderingService.delete(it.id)
+            }
+}

--- a/api/src/test/kotlin/com/wnsgml972/strada/api/products/bread/BreadControllerIT.kt
+++ b/api/src/test/kotlin/com/wnsgml972/strada/api/products/bread/BreadControllerIT.kt
@@ -10,7 +10,7 @@ import mu.KLogging
 import org.amshove.kluent.shouldBeEqualTo
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
-import org.junit.jupiter.api.MethodOrderer.OrderAnnotation
+import org.junit.jupiter.api.MethodOrderer
 import org.junit.jupiter.api.Order
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestMethodOrder
@@ -19,7 +19,7 @@ import org.springframework.http.MediaType
 import org.springframework.test.web.reactive.server.WebTestClient
 import org.springframework.test.web.reactive.server.expectBody
 
-@TestMethodOrder(OrderAnnotation::class)
+@TestMethodOrder(MethodOrderer.OrderAnnotation::class)
 class BreadControllerIT @Autowired constructor(
     private val client: WebTestClient,
     private val authHelper: AuthHelper,
@@ -28,6 +28,7 @@ class BreadControllerIT @Autowired constructor(
 
     @BeforeEach
     fun `insert dummy date before each test`() {
+
         val breadDTO = BreadDTO(
             "dummy",
             "http://breadInsertTest.com",
@@ -118,7 +119,6 @@ class BreadControllerIT @Autowired constructor(
                 result.responseBody?.price shouldBeEqualTo 10000
                 logger.debug { "result=${result.responseBody}" }
             }
-
     }
 
     @Test

--- a/api/src/test/kotlin/com/wnsgml972/strada/api/products/noncoffee/NonCoffeeControllerIT.kt
+++ b/api/src/test/kotlin/com/wnsgml972/strada/api/products/noncoffee/NonCoffeeControllerIT.kt
@@ -20,7 +20,7 @@ import org.springframework.test.web.reactive.server.WebTestClient
 import org.springframework.test.web.reactive.server.expectBody
 
 @TestMethodOrder(MethodOrderer.OrderAnnotation::class)
-class NonCoffeeControllerIT@Autowired constructor(
+class NonCoffeeControllerIT @Autowired constructor(
     private val client: WebTestClient,
     private val authHelper: AuthHelper,
     private val productHelper: ProductHelper
@@ -36,7 +36,6 @@ class NonCoffeeControllerIT@Autowired constructor(
             "insert NonCoffee",
             "NonCoffee")
         productHelper.insertNonCoffee(nonCoffeeDTO)
-
     }
 
     @AfterEach

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     restart: on-failure
     environment:
       MYSQL_DATABASE: test_db
-      MYSQL_USER: root
+#      MYSQL_USER: root
       MYSQL_PASSWORD: ''
       MYSQL_ROOT_PASSWORD: ''
       MYSQL_ALLOW_EMPTY_PASSWORD: 'true'

--- a/tools/test/docker-compose-integration.local.yml
+++ b/tools/test/docker-compose-integration.local.yml
@@ -5,7 +5,7 @@ services:
     restart: on-failure
     environment:
       MYSQL_DATABASE: test_integration_db
-      MYSQL_USER: root
+#      MYSQL_USER: root
       MYSQL_PASSWORD: ''
       MYSQL_ROOT_PASSWORD: ''
       MYSQL_ALLOW_EMPTY_PASSWORD: 'true'


### PR DESCRIPTION
- orderingdetail의 coffee, noncoffee, bread, bean의 연관관계 끊고 id로만 처리될 수 있도록 처리

<!--- Provide a general summary of your changes in the Title above --->
<!--- Please don't @-mention people in PR or commit messages (do so in an additional comment). --->

## What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Which issue/s this PR fixes
<!--
(optional, in `fixes #<issue number>` format, will close that issue when PR gets merged):
fixes #
-->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the test you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
